### PR TITLE
use teardownAll rather than tearing down individual component

### DIFF
--- a/lib/jasmine-flight.js
+++ b/lib/jasmine-flight.js
@@ -109,9 +109,9 @@
         }
 
         // reset local member variables
-        this.component.teardown();
         this.component = null;
         this.Component = null;
+        defineComponent.teardownAll();
         done();
       });
 


### PR DESCRIPTION
I was running into issues when with test cases that have already torn down the component.
